### PR TITLE
fix panic on start with backward steps

### DIFF
--- a/src/stepper.rs
+++ b/src/stepper.rs
@@ -110,7 +110,7 @@ impl StepperMotor {
 
         let mut stepper = Self {
             microsteps,
-            current_step: 0,
+            current_step: i32::MAX/2,
             channels: (*channels).clone(),
             curve,
         };


### PR DESCRIPTION
Some computations and lookups fail, when the current_step reaches numbers < 0. I think the easiest way to get around the problem is to start with current_step in the middle area of the valid number space. E.g:
https://github.com/ostrosco/adafruit_motorkit/issues/1#issuecomment-1171558728

I have tested this locally and it is working fine so far.